### PR TITLE
docs: update README.md with instructions and usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,43 @@
 # hath-docker
+
+Usage
+
+docker run
+--name hath
+--user 99:100
+-v /path/to/your/hath/cache:/hath/cache
+-v /path/to/your/hath/data:/hath/data
+-v /path/to/your/hath/download>:/hath/download
+-v /path/to/your/hath/log:/hath/log
+-v /path/to/your/hath/tmp:/hath/tmp
+-e HATH_CLIENT_ID=<Input Your HATH ID Here>
+-e HATH_CLIENT_KEY=<Input Your HATH KEY Here>
+-e UMASK=000
+-e TZ=YOUR_TIMEZONE
+-p YOUR_HATH_PORT/tcp
+cloverdefa/hath
+
+or Use docker-compose
+
+# docker-compose.yml
+
+version: "3.8"
+
+services:
+hath:
+image: cloverdefa/hath
+container_name: hath
+user: "${UID}:${GID}"
+network_mode: host
+volumes:
+- ./cache:/hath/cache
+- ./data:/hath/data
+- ./download:/hath/download
+- ./log:/hath/log
+- ./tmp:/hath/tmp
+environment:
+- HATH_CLIENT_ID: <Input Your HATH ID Here>
+- HATH_CLIENT_KEY: <Input Your HATH KEY Here>
+- UMASK: 000
+- TZ: Asia/Taipei
+restart: unless-stopped


### PR DESCRIPTION
- Update the README.md file with instructions for using the `hath-docker` image
- Add usage examples for running the image using `docker run` and `docker-compose`
- Specify the required environment variables for running the image

Signed-off-by: DAST-OfficePC <jackie@dast.tw>
