### PR TITLE
chore: update image and container configuration for /hath service

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,20 +4,20 @@
    
 ## docker  
 ```
-docker run \   
---name hath \    
---user 99:100 \     
--v /path/to/your/hath/cache:/hath/cache \   
--v /path/to/your/hath/data:/hath/data \   
--v /path/to/your/hath/download>:/hath/download \   
--v /path/to/your/hath/log:/hath/log \   
--v /path/to/your/hath/tmp:/hath/tmp \   
--e HATH_CLIENT_ID=<Input Your HATH ID Here> \   
--e HATH_CLIENT_KEY=<Input Your HATH KEY Here> \    
--e UMASK=000 \    
--e TZ=<YOUR_TIMEZONE> \   
--p <YOUR_HATH_PORT>/tcp \   
-cloverdefa/hath   
+docker run \
+--name hath \
+--user 99:100 \
+-v /path/to/your/hath/cache:/hath/cache \
+-v /path/to/your/hath/data:/hath/data \ 
+-v /path/to/your/hath/download>:/hath/download \
+-v /path/to/your/hath/log:/hath/log \
+-v /path/to/your/hath/tmp:/hath/tmp \
+-e HATH_CLIENT_ID=<Input Your HATH ID Here> \
+-e HATH_CLIENT_KEY=<Input Your HATH KEY Here> \
+-e UMASK=000 \
+-e TZ=<YOUR_TIMEZONE> \
+-p <YOUR_HATH_PORT>/tcp \
+cloverdefa/hath:latest
 ```
 
     
@@ -26,24 +26,24 @@ or Use docker-compose
 ## docker-compose.yml
 
 ```
-version: "3.8"    
-    
-services:        
-  hath:    
-    image: cloverdefa/hath    
-    container_name: hath    
-    user: "${UID}:${GID}"    
-    network_mode: host    
-    volumes:    
-      - ./cache:/hath/cache    
-      - ./data:/hath/data    
-      - ./download:/hath/download    
-      - ./log:/hath/log    
-      - ./tmp:/hath/tmp    
-    environment:    
-      - HATH_CLIENT_ID: <Input Your HATH ID Here>    
-      - HATH_CLIENT_KEY: <Input Your HATH KEY Here>    
-      - UMASK: 000    
-      - TZ: <Your TimeZone>    
-    restart: unless-stopped    
+version: "3.8"
+
+services:
+  hath:  
+    image: cloverdefa/hath:latest
+    container_name: 'hath'
+    user: "${UID}:${GID}"
+    network_mode: host 
+    volumes:
+      - ./cache:/hath/cache
+      - ./data:/hath/data  
+      - ./download:/hath/download
+      - ./log:/hath/log
+      - ./tmp:/hath/tmp
+    environment:
+      - HATH_CLIENT_ID: <Input Your HATH ID Here>
+      - HATH_CLIENT_KEY: <Input Your HATH KEY Here>
+      - UMASK: 000
+      - TZ: <Input Your TimeZone Here>
+    restart: unless-stopped
 ```


### PR DESCRIPTION
- Update the image and container name for the `hath` service
- Remove the `cloverdefa/hath` image and container name and replace with `cloverdefa/hath:latest`
- Update the value for the `TZ` environment variable to `<Input Your TimeZone Here>`
- Update the value for the `HATH_CLIENT_ID` environment variable to `<Input Your HATH ID Here>`
- Update the value for the `HATH_CLIENT_KEY` environment variable to `<Input Your HATH KEY Here>`

Signed-off-by: DAST-OfficePC <jackie@dast.tw>
