### PR TITLE
build: increase timeout and retries for healthcheck command in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ADD src/* /opt/hath/
 
 VOLUME ["/hath/cache", "/hath/data", "/hath/download", "/hath/log", "/hath/tmp"]
 
-HEALTHCHECK --interval=30s --timeout=3s  --retries=3 \
+HEALTHCHECK --interval=30s --timeout=5s --retries=5 \
     CMD curl -fs http://localhost/ || exit 1
 
 CMD ["/opt/hath/start.sh"]


### PR DESCRIPTION
- Increase the timeout and retries for the healthcheck command in the Dockerfile

Signed-off-by: HomePC-DAST <jackie@dast.tw>
