### PR TITLE
chore: remove unnecessary HEALTHCHECK command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,4 @@ ADD src/* /opt/hath/
 
 VOLUME ["/hath/cache", "/hath/data", "/hath/download", "/hath/log", "/hath/tmp"]
 
-HEALTHCHECK --interval=30s --timeout=5s --retries=5 \
-    CMD curl -fs http://localhost/ || exit 1
-
 CMD ["/opt/hath/start.sh"]


### PR DESCRIPTION
- Remove the HEALTHCHECK command that checks the health of the container

Signed-off-by: HomePC-DAST <jackie@dast.tw>
