### PR TITLE
chore: update base image and install packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM 22-slim
+FROM buildpack-deps:bookworm-scm
 LABEL MAINTAINER="cloverdefa"
 
 RUN apt-get update && apt-get install wget unzip -y && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
-FROM openjdk:alpine
+FROM openjdk11:alpine
 LABEL MAINTAINER="cloverdefa"
-
-ARG ARCH
 
 RUN apk update && apk add wget unzip && \
     mkdir -p /opt/hath && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM openjdk11:alpine
+FROM openjdk:22-bookworm
 LABEL MAINTAINER="cloverdefa"
 
-RUN apk update && apk add wget unzip && \
+RUN apt-get update && apt-get install wget unzip -y && \
     mkdir -p /opt/hath && \
     wget -O /tmp/hath-1.6.1.zip https://repo.e-hentai.org/hath/HentaiAtHome_1.6.1.zip && \
     unzip /tmp/hath-1.6.1.zip -d /opt/hath && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:22-bookworm
+FROM 22-slim
 LABEL MAINTAINER="cloverdefa"
 
 RUN apt-get update && apt-get install wget unzip -y && \


### PR DESCRIPTION
- build: update base image in Dockerfile to openjdk11:alpine
- chore: update base image and package installation method
- The label best describing this change is "build".: update base image and remove unnecessary commands
- chore: update base image and install packages
