### PR TITLE
build: update base image and package installation for Alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM buildpack-deps:bookworm-scm
+FROM openjdk:alpine
 LABEL MAINTAINER="cloverdefa"
 
-RUN apt-get update && apt-get install wget unzip -y && \
+RUN apk update && apk add wget unzip && \
     mkdir -p /opt/hath && \
     wget -O /tmp/hath-1.6.1.zip https://repo.e-hentai.org/hath/HentaiAtHome_1.6.1.zip && \
     unzip /tmp/hath-1.6.1.zip -d /opt/hath && \


### PR DESCRIPTION
- Change the base image to openjdk:alpine
- Replace `apt-get` with `apk` for package installation
- Update the download link for `hath-1.6.1.zip`

Signed-off-by: DAST-Macbook <jackie@dast.tw>
