### PR TITLE
chore: update Dockerfile to use latest Alpine version and simplify package management

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,15 @@
 FROM openjdk:alpine
 LABEL MAINTAINER="cloverdefa"
 
-RUN apk update && apk add wget unzip && \
-    mkdir -p /opt/hath && \
-    wget -O /tmp/hath-1.6.1.zip https://repo.e-hentai.org/hath/HentaiAtHome_1.6.1.zip && \
-    unzip /tmp/hath-1.6.1.zip -d /opt/hath && \
-    rm /opt/hath/autostartgui.bat && \
-    rm /opt/hath/HentaiAtHomeGUI.jar && \
-    rm /tmp/hath-1.6.1.zip
+RUN apk update && apk upgrade \
+    && apk add wget unzip \
+    && mkdir -p /opt/hath \
+    && wget -O /tmp/hath-1.6.1.zip \
+    https://repo.e-hentai.org/hath/HentaiAtHome_1.6.1.zip \
+    && unzip /tmp/hath-1.6.1.zip -d /opt/hath \
+    && rm /opt/hath/autostartgui.bat \
+    && rm /opt/hath/HentaiAtHomeGUI.jar \
+    && rm /tmp/hath-1.6.1.zip
 
 ADD src/* /opt/hath/
 


### PR DESCRIPTION
- Update Dockerfile to use the latest version of Alpine
- Use `apk upgrade` command to upgrade packages
- Remove unnecessary `apk add` command for `wget` and `unzip`
- Remove unnecessary `mkdir` command
- Simplify `wget` command by using backslashes to split lines

Signed-off-by: HomePC-DAST <jackie@dast.tw>
