### PR TITLE
chore: change temp directory path

### DIFF
--- a/src/start.sh
+++ b/src/start.sh
@@ -15,4 +15,4 @@ exec java -jar /opt/hath/HentaiAtHome.jar \
     --data-dir=/hath/data                 \
     --download-dir=/hath/download         \
     --log-dir=/hath/log                   \
-    --temp-dir=/hath/tm
+    --temp-dir=/hath/tmp


### PR DESCRIPTION
- Change the temp directory from `/hath/tm` to `/hath/tmp`

Signed-off-by: HomePC-DAST <jackie@dast.tw>
