### PR TITLE
chore: update healthcheck URL to use HTTPS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get upgrade -y \
 ADD src/* /opt/hath/
 
 HEALTHCHECK --interval=60s --start-period=180s --timeout=60s --retries=3 \
-  CMD curl -fs http://e-hentai.org || exit 1
+  CMD curl -fs https://e-hentai.org || exit 1
 
 VOLUME ["/hath/cache", "/hath/data", "/hath/download", "/hath/log", "/hath/tmp"]
 


### PR DESCRIPTION
- Change the URL in the healthcheck command from `http://e-hentai.org` to `https://e-hentai.org`

Signed-off-by: HomePC-DAST <jackie@dast.tw>
