### PR TITLE
chore: update healthcheck command in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,14 +4,14 @@ LABEL version="0.0.4-beta"
 
 WORKDIR /opt/hath 
 
-RUN 'apt-get update && apt-get upgrade -y \
+RUN apt-get update && apt-get upgrade -y \
     && apt install -y wget unzip procps \
     && wget -O /tmp/hath-1.6.1.zip \
     https://repo.e-hentai.org/hath/HentaiAtHome_1.6.1.zip \
     && unzip /tmp/hath-1.6.1.zip -d /opt/hath \
     && rm /opt/hath/autostartgui.bat \
     && rm /opt/hath/HentaiAtHomeGUI.jar \
-    && rm /tmp/hath-1.6.1.zip'
+    && rm /tmp/hath-1.6.1.zip
 
 ADD src/* /opt/hath/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:22-slim-bookworm
 LABEL MAINTAINER="cloverdefa"
-LABEL version="0.0.4-beta2"
+LABEL version="0.0.4"
 
 WORKDIR /opt/hath 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ LABEL version=["0.0.4-beta"]
 WORKDIR /opt/hath 
 
 RUN ['apt-get update && apt-get upgrade -y \
-    && apt install -y unzip procps \
+    && apt install -y wget unzip procps \
     && wget -O /tmp/hath-1.6.1.zip \
     https://repo.e-hentai.org/hath/HentaiAtHome_1.6.1.zip \
     && unzip /tmp/hath-1.6.1.zip -d /opt/hath \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,24 @@
 FROM openjdk:22-slim-bookworm
-LABEL MAINTAINER="cloverdefa"
+LABEL MAINTAINER=["cloverdefa"]
+LABEL version=["0.0.4-beta"]
 
-RUN apt-get update && apt-get upgrade -y \
-    && apt install -y wget unzip curl \
-    && mkdir -p /opt/hath \
+WORKDIR /opt/hath 
+
+RUN ['apt-get update && apt-get upgrade -y \
+    && apt install -y unzip \
     && wget -O /tmp/hath-1.6.1.zip \
     https://repo.e-hentai.org/hath/HentaiAtHome_1.6.1.zip \
     && unzip /tmp/hath-1.6.1.zip -d /opt/hath \
     && rm /opt/hath/autostartgui.bat \
     && rm /opt/hath/HentaiAtHomeGUI.jar \
-    && rm /tmp/hath-1.6.1.zip
+    && rm /tmp/hath-1.6.1.zip']
 
 ADD src/* /opt/hath/
 
+ENV PATH /usr/bin:pa /usr/bin:ps
+
 HEALTHCHECK --interval=60s --start-period=180s --timeout=60s --retries=3 \
-  CMD curl -fs https://e-hentai.org || exit 1
+  CMD ps aux | grep HentaiAtHome || exit(1)
 
 VOLUME ["/hath/cache", "/hath/data", "/hath/download", "/hath/log", "/hath/tmp"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ LABEL version=["0.0.4-beta"]
 WORKDIR /opt/hath 
 
 RUN ['apt-get update && apt-get upgrade -y \
-    && apt install -y unzip \
+    && apt install -y unzip procps \
     && wget -O /tmp/hath-1.6.1.zip \
     https://repo.e-hentai.org/hath/HentaiAtHome_1.6.1.zip \
     && unzip /tmp/hath-1.6.1.zip -d /opt/hath \
@@ -14,8 +14,6 @@ RUN ['apt-get update && apt-get upgrade -y \
     && rm /tmp/hath-1.6.1.zip']
 
 ADD src/* /opt/hath/
-
-ENV PATH /usr/bin:ps /usr/bin:ps
 
 HEALTHCHECK --interval=60s --start-period=180s --timeout=60s --retries=3 \
   CMD ps aux | grep HentaiAtHome || exit(1)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:22-slim-bookworm
 LABEL MAINTAINER="cloverdefa"
-LABEL version="0.0.4-beta"
+LABEL version="0.0.4-beta2"
 
 WORKDIR /opt/hath 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN ['apt-get update && apt-get upgrade -y \
 
 ADD src/* /opt/hath/
 
-ENV PATH /usr/bin:pa /usr/bin:ps
+ENV PATH /usr/bin:ps /usr/bin:ps
 
 HEALTHCHECK --interval=60s --start-period=180s --timeout=60s --retries=3 \
   CMD ps aux | grep HentaiAtHome || exit(1)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,17 @@
 FROM openjdk:22-slim-bookworm
-LABEL MAINTAINER=["cloverdefa"]
-LABEL version=["0.0.4-beta"]
+LABEL MAINTAINER="cloverdefa"
+LABEL version="0.0.4-beta"
 
 WORKDIR /opt/hath 
 
-RUN ['apt-get update && apt-get upgrade -y \
+RUN 'apt-get update && apt-get upgrade -y \
     && apt install -y wget unzip procps \
     && wget -O /tmp/hath-1.6.1.zip \
     https://repo.e-hentai.org/hath/HentaiAtHome_1.6.1.zip \
     && unzip /tmp/hath-1.6.1.zip -d /opt/hath \
     && rm /opt/hath/autostartgui.bat \
     && rm /opt/hath/HentaiAtHomeGUI.jar \
-    && rm /tmp/hath-1.6.1.zip']
+    && rm /tmp/hath-1.6.1.zip'
 
 ADD src/* /opt/hath/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update && apt-get upgrade -y \
 ADD src/* /opt/hath/
 
 HEALTHCHECK --interval=60s --start-period=180s --timeout=60s --retries=3 \
-  CMD ps aux | grep HentaiAtHome || exit(1)
+  CMD jps | grep 'HentaiAtHome.jar' || exit
 
 VOLUME ["/hath/cache", "/hath/data", "/hath/download", "/hath/log", "/hath/tmp"]
 


### PR DESCRIPTION
- Update Dockerfile with new maintainer and version
- Fix Dockerfile environment variable path
- Update Dockerfile: add procps package, remove unnecessary environment variable
- Update Dockerfile: add wget to apt install
- build: update Docker image and file structure
- chore: refactor Dockerfile by removing unnecessary `RUN` command
- chore: update healthcheck command in Dockerfile
- chore: update version label in Dockerfile to "0.0.4-beta2"
- chore: update version label in Dockerfile to 0.0.4
