### PR TITLE
build: update Dockerfile to use version 1.6.1 of HentaiAtHome

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:22-slim-bookworm
 LABEL MAINTAINER="cloverdefa"
-LABEL version="0.0.5"
+LABEL version="0.0.6-beta"
 
 WORKDIR /opt/hath
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:22-slim-bookworm
 LABEL MAINTAINER="cloverdefa"
-LABEL version="0.0.6-beta"
+LABEL version="0.0.6"
 
 WORKDIR /opt/hath
 


### PR DESCRIPTION
- chore: update Dockerfile version label
- chore: update version label in Dockerfile
