### PR TITLE
chore: update Dockerfile and ARG variable in HATH_VERSION

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 FROM openjdk:22-slim-bookworm
 LABEL MAINTAINER=["cloverdefa"]
-LABEL version=["0.0.6-beta"]
+LABEL version=["0.0.6"]
 
 WORKDIR /opt/hath
 
-ARG ['HATH_VERSION=1.6.1']
+ARG HATH_VERSION=1.6.1
 
 RUN apt-get update && apt-get upgrade -y \
     && apt install -y wget unzip \


### PR DESCRIPTION
- Update the version label in the Dockerfile from "0.0.6-beta" to "0.0.6"
- Update the value of the ARG variable HATH_VERSION from "'HATH_VERSION=1.6.1'" to "HATH_VERSION=1.6.1"

Signed-off-by: DAST-OfficePC <jackie@dast.tw>
