### PR TITLE
chore: update Dockerfile label version to 0.0.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:22-slim-bookworm
 LABEL MAINTAINER=cloverdefa
-LABEL version=0.0.7
+LABEL VERSION=0.0.7
 
 ARG HATH_VERSION=1.6.1
 


### PR DESCRIPTION
- Update the `LABEL VERSION` from `0.0.7` to `0.0.7`
- No other relevant changes in the Dockerfile.

Signed-off-by: HomePC-DAST <jackie@dast.tw>
