### PR TITLE
chore: add necessary files for HentaiAtHomeGUI deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,7 @@ RUN apt-get update && apt-get upgrade -y \
     && apt-get install -y unzip \
     && unzip /opt/hath/HentaiAtHome_${HATH_VERSION}.zip \
     && rm /opt/hath/autostartgui.bat \
-    && rm /opt/hath/HentaiAtHomeGUI.jar \
-    && rm /opt/hath/HentaiAtHome_${HATH_VERSION}.zip \
+    HentaiAtHomeGUI.jar HentaiAtHome_${HATH_VERSION}.zip \
     && apt-get remove -y unzip
 
 HEALTHCHECK --interval=30s --timeout=30s --start-period=60s --retries=3 \


### PR DESCRIPTION
- Remove unnecessary lines for removing files
- Add `HentaiAtHomeGUI.jar` and `HentaiAtHome_${HATH_VERSION}.zip`

Signed-off-by: HomePC-DAST <jackie@dast.tw>
