### PR TITLE
build: update base image to openjdk:8-jre-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jdk-alpine
+FROM openjdk:8-jre-alpine
 LABEL MAINTAINER=cloverdefa
 LABEL VERSION=0.0.8
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:8-jre-alpine
 LABEL MAINTAINER=cloverdefa
-LABEL VERSION=0.0.8
+LABEL VERSION=0.0.9
 
 ARG HATH_VERSION=1.6.1
 


### PR DESCRIPTION
- build: update base image to `openjdk:8-jre-alpine`
- chore: update Dockerfile version label to 0.0.9
