### PR TITLE
build: refactor Dockerfile to improve package installation efficiency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,7 @@ WORKDIR /opt/hath
 
 COPY start.sh /opt/hath/
 
-RUN apk update && apk upgrade \
-    && apk add --virtual build-hath wget unzip \
+RUN apk add --update --no-cache --virtual build-hath wget unzip \
     && wget -O /tmp/hath-$HATH_VERSION.zip \
     https://repo.e-hentai.org/hath/HentaiAtHome_$HATH_VERSION.zip \
     && unzip /tmp/hath-$HATH_VERSION.zip -d /opt/hath \


### PR DESCRIPTION
- Update Dockerfile to use `apk add` instead of `apk update`, `apk upgrade`, and `apk add`
- Use `--no-cache` option when adding packages with `apk` command

Signed-off-by: DAST-Macbook <jackie@dast.tw>
