### PR TITLE
chore: update configuration and README.md file for environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ services:
   hath:  
     image: cloverdefa/hath:latest
     container_name: hath
-    user: <Input Your UID Here>:<Input Your GID Here>
+    user: $UGID
     network_mode: host
     restart: unless-stopped
     volumes:
@@ -44,9 +44,17 @@ services:
       - ./log:/hath/log
       - ./tmp:/hath/tmp
     environment:
-      HATH_CLIENT_ID: <Input Your HATH ID Here>
-      HATH_CLIENT_KEY: <Input Your HATH KEY Here>
+      HATH_CLIENT_ID: $HATH_CLIENT_ID
+      HATH_CLIENT_KEY: $HATH_CLIENT_KEY
       UMASK: 000
+```
+
+### .env file (if use docker-compose)
+```
+HATH_CLIENT_ID: 00000
+HATH_CLIENT_KEY: aaabbbcccddd
+UGID: 1000:1000
+
 ```
    
 ## Docker Hub


### PR DESCRIPTION
- Update the `user` field in the `hath` service configuration to use the `$UGID` environment variable instead of static values for UID and GID
- Update the `HATH_CLIENT_ID` and `HATH_CLIENT_KEY` environment variables in the `hath` service configuration to use the `$HATH_CLIENT_ID` and `$HATH_CLIENT_KEY` environment variables respectively
- Add a new section in the README.md file for the `.env` file if using docker-compose
- Add example values for `HATH_CLIENT_ID`, `HATH_CLIENT_KEY`, and `UGID` in the `.env` file section of the README.md file

Signed-off-by: OfficePC-DAST <jackie@dast.tw>
