### PR TITLE
chore: refactor installation process and update download URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,7 @@ WORKDIR /opt/hath
 
 ADD start.sh /opt/hath/
 
-RUN apt-get update && apt-get dist-upgrade -y \
-    && apt-get install wget unzip -y \
+RUN apt-get update && apt-get install wget unzip -y \
     && wget -O /tmp/hath-$HATH_VERSION.zip \
     https://repo.e-hentai.org/hath/HentaiAtHome_$HATH_VERSION.zip \
     && unzip /tmp/hath-$HATH_VERSION.zip -d /opt/hath \


### PR DESCRIPTION
Based on these changes, the best label for the commit would be "chore".: update Dockerfile and change source URL for downloading Hath

- Update the Dockerfile to only install wget and unzip instead of performing a dist-upgrade
- Change the source URL for downloading Hath to use the repo.e-hentai.org domain

Signed-off-by: HomePC-DAST <jackie@dast.tw>
