### PR TITLE
chore: ignore generated files and folders in version control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,10 +5,13 @@
 .md
 *.code-workspace
 *.spec
+pyproject.toml
+poetry.lock
 
 # 忽略資料夾
 __pycache__/
 .vscode/
+.venv/
 build/
 dist/
 


### PR DESCRIPTION
- Added `pyproject.toml` to the `.gitignore`
- Added `poetry.lock` to the `.gitignore`
- Ignoring the `__pycache__/` folder
- Ignoring the `.vscode/` folder
- Ignoring the `.venv/` folder
- Ignoring the `build/` folder
- Ignoring the `dist/` folder

Signed-off-by: DAST-Macbook <jackie@dast.tw>
