### PR TITLE
ci: 新增 GitHub Actions 工作流程，用於建立和推送 Docker 映像

### DIFF
--- a/.github/workflows/push-docker.yml
+++ b/.github/workflows/push-docker.yml
@@ -1,0 +1,29 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - 'main'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      -
+        name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          push: true
+          tags: cloverdefa/hath:latest


### PR DESCRIPTION
- 新增了一個新檔案：`.github/workflows/push-docker.yml`
- 建立了一個用於 CI 的 GitHub Actions 工作流程
- 在 `main` 分支推送時觸發
- 配置了 QEMU 和 Docker Buildx
- 使用密鑰登入了 Docker Hub
- 建立並推送了一個具有標籤 `cloverdefa/hath:latest` 的 Docker 映像
