### PR TITLE
ci：為Docker映像建立和推送添加GitHub Actions工作流程

### DIFF
--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -1,0 +1,29 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - "test"
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: cloverdefa/hath:test


### PR DESCRIPTION
- 添加新文件`.github/workflows/docker-push.yml`
- 設置名為`ci`的工作流程，在對`test`分支進行推送時運行
- 將`ubuntu-latest`運行程序用於`docker`任務
- 包含檢出存儲庫、設置QEMU、設置Docker Buildx和登錄到Docker Hub的步驟
- 使用當前目錄的上下文構建和推送Docker映像
- 指定Docker映像的平台為`linux/amd64`和`linux/arm64`
- 使用標籤`cloverdefa/hath:test`推送Docker映像
