### PR TITLE
ci: 新增 GitHub Actions 工作流程以推送 Docker 鏡像

### DIFF
--- a/.github/workflows/docker-push-new.yml
+++ b/.github/workflows/docker-push-new.yml
@@ -1,0 +1,29 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - "main"
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: cloverdefa/hath:0.1.8


### PR DESCRIPTION
- 新增 GitHub Actions 工作流程以推送 Docker 鏡像
- 設定工作流程在主分支上運行
- 在工作流程中設置 QEMU 和 Docker Buildx
- 新增步驟以使用密鑰登錄到 Docker Hub
- 構建並推送帶有指定標籤的 Docker 鏡像
