### PR TITLE
ci: 更新分支觸發器和 HATH 版本

### DIFF
--- a/.github/workflows/docker-push-latest.yml
+++ b/.github/workflows/docker-push-latest.yml
@@ -3,7 +3,7 @@ name: ci
 on:
   push:
     branches:
-      - "feature"
+      - "main"
     
 env:
   HATH_VERSION: 1.6.2


### PR DESCRIPTION
- 將觸發工作流程的分支從「feature」更改為「main」
- 更新 HATH_VERSION 環境變數為 1.6.2
