### PR TITLE
任務: 重新設計 HentaiAtHome 的部署流程

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,12 +18,9 @@ ARG HATH_VERSION
 
 WORKDIR /opt/hath
 
-COPY --from=build-hath /app/ /opt/hath/
+COPY --from=build-hath /app/HentaiAtHome.jar /opt/hath/
 
 ADD start.sh /opt/hath/
-
-HEALTHCHECK --interval=30s --timeout=30s --start-period=60s --retries=3 \
-    CMD pgrep java|grep "1"||exit
 
 VOLUME ["/hath/cache", "/hath/data", "/hath/download", "/hath/log", "/hath/tmp"]
 


### PR DESCRIPTION
- 只複製 HentaiAtHome.jar 檔案，而非整個 /app 目錄
- 移除檢查運行中 Java 程序的健康檢查命令
- 指定 /hath 目錄的儲存區

Signed-off-by: DAST-OfficePC <jackie@dast.tw>
