### PR TITLE
建構: 重構建構流程和 Dockerfile 以提高效率

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest AS build-hath
+FROM alpine:latest AS get-hath
 
 ARG HATH_VERSION=1.6.2
 WORKDIR /app
@@ -12,7 +12,7 @@ LABEL MAINTAINER="cloverdefa"
 
 WORKDIR /opt/hath
 
-COPY --from=build-hath /app/HentaiAtHome.jar /opt/hath/
+COPY --from=get-hath /app/HentaiAtHome.jar /opt/hath/
 
 ADD start.sh /opt/hath/
 


### PR DESCRIPTION
- 將建構階段重新命名為「get-hath」
- 更新 Dockerfile，從「get-hath」階段複製 jar 檔案

Signed-off-by: DAST-OfficePC <jackie@dast.tw>
