### PR TITLE
構建：更新基礎映像並優化套件安裝和文件處理

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,16 +1,18 @@
+# 第一階段
 FROM alpine:latest AS get-hath
 ENV HATH_VERSION="1.6.2"
 
-RUN apk add wget unzip \
+RUN apk add --no-cache wget unzip \
     && wget https://repo.e-hentai.org/hath/HentaiAtHome_$HATH_VERSION.zip \
-    && unzip HentaiAtHome_$HATH_VERSION.zip
+    && unzip HentaiAtHome_$HATH_VERSION.zip -d /tmp
 
+# 第二階段
 FROM amazoncorretto:latest
 LABEL MAINTAINER="cloverdefa"
 
-RUN mkdir /opt/hath && mkdir /hath
+RUN mkdir -p /opt/hath /hath
 
-COPY --from=get-hath ./HentaiAtHome.jar /opt/hath/
+COPY --from=get-hath /tmp/HentaiAtHome.jar /opt/hath/
 COPY /RUN/run.sh /opt/hath/
 
 VOLUME ["/hath/cache", "/hath/data", "/hath/download", "/hath/log", "/hath/tmp"]


### PR DESCRIPTION
- 從 `alpine:latest` 更改為 `amazoncorretto:latest` 基礎映像
- 在第一階段安裝套件時添加 `--no-cache` 標誌
- 解壓 Hath 壓縮文件時更改目標目錄
- 在第二階段創建目錄時使用 `-p` 標誌
- 在 `COPY` 命令中更新 Hath jar 文件的路徑

Signed-off-by: OfficePC-DAST <jackie@dast.tw>
