### PR TITLE
事務：更新版權持有人、使用者欄位和.env示例

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 cloverdefa
+Copyright (c) 2023 DAST
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the “Software”), to deal

--- a/README.md
+++ b/README.md
@@ -37,8 +37,7 @@ services:
     image: cloverdefa/hath:latest   
     restart: unless-stopped   
     network_mode: host   
-    PUID: ${HOST_UID} # 使用 .env 內設定的 UID   
-    PGID: ${HOST_GID} # 使用 .env 內設定的 GID   
+    user: ${ID}  #  使用 .env 內設定的 UID:GID   
     volumes:   
       - ./cache:/hath/cache   
       - ./data:/hath/data   
@@ -55,8 +54,7 @@ services:
 如果你使用docker-compose來運作容器，推薦你建立.env檔案來保存你的ID以及KEY  
 ### .env(範例)   
 ```
-HOST_UID: 1000    #  設定你的 UID   
-HOST_GID: 1000    #  設定你的 GID   
+ID: 1000:100  #  設定你的 UID:GID  
 HATH_CLIENT_ID: 00000    #  設定你的 H@H client id   
 HATH_CLIENT_KEY: aaabbbccc    #  設定你的 H@H client key   
 ```


### PR DESCRIPTION
- 在LICENSE.md中將版權持有人從"cloverdefa"更改為"DAST"
- 在docker-compose.yml文件中更新使用者欄位，使用.env文件中的ID
- 在README.md中更新.env示例，使用格式為UID：GID的ID
