### PR TITLE
CI: 更新 GitHub Action 版本以提高兼容性

### DIFF
--- a/.github/workflows/docker-push-latest.yml
+++ b/.github/workflows/docker-push-latest.yml
@@ -13,18 +13,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.2
+        uses: actions/checkout@v4
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3.0.0
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.1.0
+        uses: docker/setup-buildx-action@v3
       - name: Login to Docker Hub
-        uses: docker/login-action@v3.1.0
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push
-        uses: docker/build-push-action@v5.2.0
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: ./docker/Dockerfile


### PR DESCRIPTION
- 分别將 GitHub Action 版本更新為 v4、v3 和 v5
