### PR TITLE
build: update Docker image versions and base image dependencies

### DIFF
--- a/.github/workflows/docker-push-latest.yml
+++ b/.github/workflows/docker-push-latest.yml
@@ -6,7 +6,7 @@ on:
       - "main"
 
 env:
-  IMAGE_VERSION: 0.3.6
+  IMAGE_VERSION: 0.3.7
 
 jobs:
   docker:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,7 +8,7 @@ RUN apk add --no-cache wget unzip \
     && [ -f "/tmp/HentaiAtHome.jar" ] || exit 1
 
 # 第二階段
-FROM amazoncorretto:22-alpine3.19
+FROM amazoncorretto:8-alpine3.20-jre
 LABEL maintainer="cloverdefa<jackie@dast.tw>"
 
 WORKDIR /hath


### PR DESCRIPTION
- Update `IMAGE_VERSION` from `0.3.6` to `0.3.7` in docker-push-latest.yml
- Change the base image `FROM amazoncorretto:22-alpine3.19` to `FROM amazoncorretto:8-alpine3.20-jre`

Signed-off-by: OfficePC-WSL <jackie@dast.tw>
