### PR TITLE
GIT 提交訊息：

### DIFF
--- a/.github/workflows/docker-push-latest.yml
+++ b/.github/workflows/docker-push-latest.yml
@@ -6,7 +6,7 @@ on:
       - "main"
 
 env:
-  IMAGE_VERSION: 0.4.2
+  IMAGE_VERSION: 0.4.3
 
 jobs:
   docker:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,7 +9,7 @@ RUN apk add --no-cache wget unzip \
     && [ -f "/tmp/HentaiAtHome.jar" ]
 
 # 第二階段
-FROM amazoncorretto:23.0.1-alpine
+FROM amazoncorretto:24.0.1-alpine3.21
 LABEL maintainer="cloverdefa <jackie@dast.tw>"
 
 WORKDIR /hath


### PR DESCRIPTION
chore: 在 CI 工作流程中升級 Docker 映像版本

- 在 GitHub Actions 工作流程中將映像版本從 0.4.2 更新為 0.4.3
- 在 Dockerfile 中將基礎 Docker 映像從 amazoncorretto:23.0.1-alpine 更改為 amazoncorretto:24.0.1-alpine3.21

Signed-off-by: WSL <jackie@dast.tw>
