### PR TITLE
ci: 更新 CI 工作流程以使用較舊的 Docker 基礎映像版本

### DIFF
--- a/.github/workflows/docker-push-latest.yml
+++ b/.github/workflows/docker-push-latest.yml
@@ -1,13 +1,11 @@
+---
 name: ci
-
 on:
   push:
     branches:
-      - "main"
-
+      - main
 env:
-  IMAGE_VERSION: 0.4.3
-
+  IMAGE_VERSION: 0.4.4
 jobs:
   docker:
     runs-on: ubuntu-latest

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,7 +9,7 @@ RUN apk add --no-cache wget unzip \
     && [ -f "/tmp/HentaiAtHome.jar" ]
 
 # 第二階段
-FROM amazoncorretto:24.0.1-alpine3.21
+FROM amazoncorretto:8u462-alpine3.22-jre
 LABEL maintainer="cloverdefa <jackie@dast.tw>"
 
 WORKDIR /hath


### PR DESCRIPTION
- 將 GitHub Actions 工作流程中的 Docker 映像版本從 0.4.3 更新至 0.4.4
- 修改工作流程的 push 觸發條件中分支名稱語法，移除 main 周圍的引號
- 調整 Dockerfile，改用較舊的 Amazon Corretto 基礎映像版本 8u462-alpine3.22-jre，取代 24.0.1-alpine3.21

Signed-off-by: WSL <jackie@dast.tw>
